### PR TITLE
Initialise go modules and update gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,10 @@
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
+
+# IDE generated files and folders
+.vscode
+.idea
+
+# OS generated files
+.DS_Store

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/linqk/shortnr
+
+go 1.12


### PR DESCRIPTION
This adds a basic go modules `go.mod` file and updates the `.gitignore` file.

- The `go.mod` file has no dependencies just yet as we have just run `go mod init` and no go code exists.
- The `.gitignore` file was updated to also exclude some `IDE` specific files such as those generated by `goland` and `vscode` as well as `OS` specific files such as the `.DS_Store` files created on mac os.